### PR TITLE
Fix format issues in manual pages. Add info-dir-section.

### DIFF
--- a/doc/latex2png.1
+++ b/doc/latex2png.1
@@ -1,11 +1,11 @@
 .TH LATEX2PNG "1" "October 2012" "latex2png 1.9\n" "User Commands"
 .SH NAME
-latex2png \- manual page for latex2png 1.1
+latex2png \- Convert a LaTeX file to a PNG image
 .SH DESCRIPTION
 latex2png \fB\-\-\fR Convert a LaTeX file to a PNG image
-.PP
-USAGE: latex2png [-d density] [-h] [-k] [-c] [-g] [-m] [-H home dir] file[.tex|.eps]
-.PP
+.SH SYNOPSIS
+latex2png [\-d density] [\-h] [\-k] [\-c] [\-g] [\-m] [\-H home dir] file[.tex|.eps]
+.SH DESCRIPTION
 The
 .I latex2png
 command converts a LaTeX file into a PNG image.  The first page is
@@ -13,7 +13,7 @@ translated into an image at the specified resolution.
 .I latex2png
 can also be used to convert encapsulated postscript (EPS) files to
 PNG images.  
-.SS "OPTIONS:"
+.SH OPTIONS
 .HP
 \fB\-c\fR produce color image
 .TP
@@ -39,7 +39,7 @@ that it needs to include.
 (default)
 .TP
 \fB\-v\fR version
-.SS "EXAMPLES:"
+.SH EXAMPLES
 .TP
 latex2png \fB\-d\fR 144 /tmp/file
 #create /tmp/file.png at 144 dpi

--- a/doc/latex2rtf.1
+++ b/doc/latex2rtf.1
@@ -1,21 +1,21 @@
 .TH LATEX2RTF "1" "October 2012" "latex2rtf 2.3" "User Commands"
 .SH NAME
 latex2rtf \- Convert a LaTeX file to an RTF file
-.SH SYNTAX
-latex2rtf [-hlpFSVW] [ -d# ] [ -D# ] [ -M# ]  [ -se#] [ -sf#] [ -t# ] [ -Z# 
-] [ -a
+.SH SYNOPSIS
+latex2rtf [\-hlpFSVW] [ \-d# ] [ \-D# ] [ \-M# ]  [ \-se#] [ \-sf#] [ \-t# ] [ \-Z#
+] [ \-a
 .I auxfile
-] [ -b
+] [ \-b
 .I bblfile
-] [ -C
+] [ \-C
 .I codepage
-]  [ -i
+]  [ \-i
 .I language
-] [ -o
+] [ \-o
 .I outputfile
-] [ -P
+] [ \-P
 .I /path/to/cfg
-] [ -T
+] [ \-T
 .I /path/to/tmp
 ] [
 .I inputfile
@@ -26,41 +26,42 @@ The
 .I latex2rtf
 command converts a LaTeX file into RTF text format. The text and much of the formatting
 information is translated to RTF.
+.SH OPTIONS
 .TP
 .B \-a auxfile
 Used to specify a particular cross-referencing file.
-When this option is omitted, the 
-.I auxfile 
-is assumed to be the same as 
+When this option is omitted, the
+.I auxfile
+is assumed to be the same as
 .I inputfile
 with the .tex suffix replaced by .aux.
 .TP
 .B \-b bblfile
-Used to specify a particular bibliography file 
+Used to specify a particular bibliography file
 When this option is omitted, the
-.I bblfile 
-is assumed to be the same as 
+.I bblfile
+is assumed to be the same as
 .I inputfile
 with the .tex suffix replaced by .bbl.
-.TP 
+.TP
 .B \-C codepage
 used to specify the character set (code page) used in the LaTeX
-document for non-ansi characters. 
+document for non-ansi characters.
 .I codepage
 may be one of the following:
 ansinew, applemac, cp437, cp437de, cp850, cp852, cp855, cp865, cp866, decmulti,
 cp1250, cp1252, koi8-r, koi8-u, latin1, latin2, latin3, latin4, latin5, latin9,
-maccyr, macukr, next, raw, raw437, raw852, raw1250, raw1251, and raw1253.  
-The default behavior is to use ansinew (same as cp1252).  For convenience, just 
+maccyr, macukr, next, raw, raw437, raw852, raw1250, raw1251, and raw1253.
+The default behavior is to use ansinew (same as cp1252).  For convenience, just
 the numbers 437, 437de, 850, 852, 855, 866, 1250 or 1252 may be specified.
 
 The raw character set encoding prevents any 8-bit character translation.  The
 RTF file is marked to use the same encoding as the default encoding for the
 program interpreting the RTF file.  This is particularly useful when translating
-a file written in a language (e.g., czech) that maps poorly into the ansinew 
-(western european) character set.  
+a file written in a language (e.g., czech) that maps poorly into the ansinew
+(western european) character set.
 
-.TP 
+.TP
 .B \-d#
 Write extra debugging output to stderr.  Higher numbers cause more debugging output
 and range from 0 (only errors) to 6 (absurdly many messages). The default is
@@ -68,46 +69,46 @@ and range from 0 (only errors) to 6 (absurdly many messages). The default is
 .TP
 .B \-D dots_per_inch
 Used to specify the number of dots per inch in equations that are converted to
-bitmaps and for graphics that must be converted.  Default is 300 dpi. 
+bitmaps and for graphics that must be converted.  Default is 300 dpi.
 .TP
-.B \-E# 
+.B \-E#
 where # selects the type of figure handling desired.  RTF does not support insertion
 of PS, PDF, or EPS file types.  These figures must be converted to a bitmap format
 and then inserted.  One trick is to insert the filenames into the RTF file and then
 in post-processing, insert the file.  These options can be added together.
-.br 
--E3 insert all figures (DEFAULT)
-.br 
--E0 no figures in the RTF
-.br 
--E1 insert figures having RTF-supported formats
-.br 
--E2 convert and insert unsupported figure formats 
 .br
--E4 insert only filenames for supported file formats
-.br 
--E8 insert only filenames for unsupported file formats
+\-E3 insert all figures (DEFAULT)
+.br
+\-E0 no figures in the RTF
+.br
+\-E1 insert figures having RTF-supported formats
+.br
+\-E2 convert and insert unsupported figure formats
+.br
+\-E4 insert only filenames for supported file formats
+.br
+\-E8 insert only filenames for unsupported file formats
 .TP
 .B \-f use fields
--f0
-do not use fields in RTF.  This is handy when primitive RTF 
+\-f0
+do not use fields in RTF.  This is handy when primitive RTF
 editors are being used to view the RTF output.
-.br 
--f1 use fields for equations but not \\ref and \\cite.  
-.br 
--f2 use fields for \\ref and \\cite but not equations.  
-.br 
--f3 use fields when possible.  This is the default and is most useful when
+.br
+\-f1 use fields for equations but not \\ref and \\cite.
+.br
+\-f2 use fields for \\ref and \\cite but not equations.
+.br
+\-f3 use fields when possible.  This is the default and is most useful when
 the RTF file is being exported to be used in Word.  This retains the most
 information from the original LaTeX file.
 .TP
 .B \-F
 use LaTeX to create bitmaps for all figures.  This may help when figures are
 not translated properly.
-.TP 
+.TP
 .B \-h
 Print a short usage note
-.TP 
+.TP
 .B \-i language
 used to set the idiom or language used in the LaTeX document
 .I language
@@ -118,47 +119,47 @@ german, icelandic, irish,italian, latin, lsorbian, magyar, norsk,
 nynorsk, polish, portuges, romanian, russian, samin, scottish, serbian,
 slovak, slovene, spanish, swedish, turkish, usorbian, welsh.  The default
 is english.
-.TP 
+.TP
 .B \-l
-Assume LaTeX source uses ISO 8859-1 (Latin-1) special characters (default behavior). 
-.TP 
+Assume LaTeX source uses ISO 8859-1 (Latin-1) special characters (default behavior).
+.TP
 .B \-o outputfile
 Redirect output to
 .I outputfile
-Unless an 
+Unless an
 .I outputfile
-is specified with the -o option, the resulting RTF is produced in a file with .tex
+is specified with the \-o option, the resulting RTF is produced in a file with .tex
 replaced by .rtf.
 .TP
 .B \-M#
-where # selects the type of equation conversion.  
-.br 
--M1 displayed equations to RTF
-.br 
--M2 inline equations to RTF
-.br 
--M4 displayed equations to bitmap
-.br 
--M8 inline equations to bitmap
-.br 
--M16 insert Word comment field containing the raw LaTeX equation
-.br 
--M32 insert raw LaTeX equation delimited by $...$ and \\[...\\]
-.br 
--M64 displayed equations to EPS files with filenames in RTF
-.br 
--M128 inline equations to EPS files with filenames in RTF
-.br 
+where # selects the type of equation conversion.
+.br
+\-M1 displayed equations to RTF
+.br
+\-M2 inline equations to RTF
+.br
+\-M4 displayed equations to bitmap
+.br
+\-M8 inline equations to bitmap
+.br
+\-M16 insert Word comment field containing the raw LaTeX equation
+.br
+\-M32 insert raw LaTeX equation delimited by $...$ and \\[...\\]
+.br
+\-M64 displayed equations to EPS files with filenames in RTF
+.br
+\-M128 inline equations to EPS files with filenames in RTF
+.br
 .TP
 These options may be added together to get different results
 .br
--M0 no equations fields in the RTF.  
+\-M0 no equations fields in the RTF.
 .br
--M3 converts both inline and displayed equations to RTF (DEFAULT).  
-.br 
--M12 converts inline and displayed equations to bitmaps.  
+\-M3 converts both inline and displayed equations to RTF (DEFAULT).
 .br
--M192 converts inline and displayed equations to eps files and inserts a tag in RTF.  
+\-M12 converts inline and displayed equations to bitmaps.
+.br
+\-M192 converts inline and displayed equations to eps files and inserts a tag in RTF.
 .br
 Bitmap conversion requires a working latex2png script.  Producing bitmaps is slow.
 .TP
@@ -166,64 +167,64 @@ Bitmap conversion requires a working latex2png script.  Producing bitmaps is slo
 Escape printed parentheses in mathematical formulas, as some versions of
 Word (e.g Word 2000) have deep psychological problems with EQ fields using quoted parentheses.
 If Word displays some formulas with parentheses as 'Error!', try this option.
-See also the -S option.
-.TP 
+See also the \-S option.
+.TP
 .B \-P /path/to/cfg
 used to specify the directory that contains the @code{.cfg} files
 .TP
 .B \-se#
-selects the scale for equation conversion, where # is the scale factor 
+selects the scale for equation conversion, where # is the scale factor
 (default 1.00).
 .TP
 .B \-sf#
 selects the scale for figure conversion, where # is the scale factor
 (default 1.00).
-.TP 
+.TP
 .B \-S
 Use semicolons to separate arguments in RTF fields.
 This is needed when the machine opening the RTF file
 has a version of Word that uses commas for decimal points.
 This also can fix displaying some formulas as 'Error!'
-You may also need to try the -p option.
+You may also need to try the \-p option.
 .TP
 .B \-t#
 selects the type of table conversion.
-.br 
--t1 convert tables to RTF (default)
-.br 
--t2 convert tables to bitmaps
+.br
+\-t1 convert tables to RTF (default)
+.br
+\-t2 convert tables to bitmaps
 .TP
 .B \-T /path/to/tmp
 used to specify the folder where to put temporary files.
 .TP
 .B \-V
 Prints version on standard output and exits.
-.TP 
-.B \-W 
-Emit warnings directly in RTF file.  Handy for catching things that do not 
+.TP
+.B \-W
+Emit warnings directly in RTF file.  Handy for catching things that do not
 get translated correctly.
-.TP 
-.B \-Z# 
+.TP
+.B \-Z#
 Add # close braces to end of RTF file.  (Handy when file is not converted
 correctly and will not open in another word processor.)
 .SH CONFIGURATION FILES
 The configuration files are searched first in any directory specified
-by -P, then in the location specified by the environment variable 
-RTFPATH, and finally in the location CFGDIR specified when 
+by \-P, then in the location specified by the environment variable
+RTFPATH, and finally in the location CFGDIR specified when
 .I
 latex2rtf
 was compiled.  If the configuration files are not found then
 .I
-latex2rtf 
-aborts.  The configuration files allow additional fonts to be 
-recognized, additional simple commands to be translation, and 
+latex2rtf
+aborts.  The configuration files allow additional fonts to be
+recognized, additional simple commands to be translation, and
 additional commands to be ignored.
 .SH CAUTION
 The input file must be a valid LaTeX file. Use LaTeX
 to find and fix errors before converting with
 .I latex2rtf.
 .PP
-The configuration files 
+The configuration files
 .B direct.cfg
 and
 .B fonts.cfg
@@ -236,18 +237,18 @@ to suit your needs.
 .SH BUGS
 Some might consider RTF to be a bug.
 .PP
-Some environments are currently ignored. 
+Some environments are currently ignored.
 .PP
 Translation without a LaTeX generated .aux file is poor.
 .SH REPORTING BUGS
-Report bugs to to the bug tracking system at http://sourceforge.net/projects/latex2rtf/. 
+Report bugs to to the bug tracking system at http://sourceforge.net/projects/latex2rtf/.
 Only report bugs for the latest version of
 .I latex2rtf
 that is available.  Please identify your operating system.
 
 .PP
 If the program produces wrong output or does not work for you, INCLUDE
-A SHORT LATEX FILE that demonstrates the problem.  The shorter the 
+A SHORT LATEX FILE that demonstrates the problem.  The shorter the
 LaTeX file, the quicker your bug will get addressed.  Bug reports with
 non-existent LaTeX files are not welcomed by the developers.
 Do not bother to send RTF files, since these are usually unhelpful.
@@ -262,4 +263,3 @@ or the HTML file
 .B latex2rtf.html
 which are made from the TeXInfo source file
 .BR latex2rtf.texi.
-

--- a/doc/latex2rtf.texi
+++ b/doc/latex2rtf.texi
@@ -7,6 +7,11 @@
 @dircategory Document Preparation
 @c %**end of header
 
+@dircategory TeX
+@direntry
+* latex2rtf: (latex2rtf).   A converter from LaTeX to RTF.
+@end direntry
+
 @ignore Permission is granted to process this file through TeX and print
 the results, provided the printed document carries a copying permission
 notice identical to this one except for the removal of this paragraph


### PR DESCRIPTION
This applies a Debian patch by @juliangilbey and @dleidert

https://sources.debian.org/src/latex2rtf/2.3.18a-5/debian/patches/manpage_formal_fixes.patch/

Fixes http://bugs.debian.org/528878