### PR TITLE
FIX: resolve segfaults with diagnostics with g_parser_depth<0

### DIFF
--- a/convert.c
+++ b/convert.c
@@ -54,7 +54,7 @@ void ConvertString(const char *string)
      purpose : converts string in TeX-format to Rtf-format
  ******************************************************************************/
 {
-    if (string == NULL || string == '\0')
+    if (string == NULL || *string == '\0')
         return;
 
     if (PushSource(NULL, string) == 0) {

--- a/parser.c
+++ b/parser.c
@@ -138,7 +138,7 @@ char *CurrentFileName(void)
 {
     char *s = "(Not set)";
 
-    if (g_parser_stack[g_parser_depth].file_name)
+    if (g_parser_depth >= 0 && g_parser_stack[g_parser_depth].file_name)
         return g_parser_stack[g_parser_depth].file_name;
     else
         return s;
@@ -322,7 +322,7 @@ void PopSource(void)
         g_parser_line = g_parser_stack[g_parser_depth].file_line;
     }
 
-    if (g_parser_file)
+    if (g_parser_depth >= 0 && g_parser_file)
         diagnostics(4, "Resuming Source File '%s'", g_parser_stack[g_parser_depth].file_name);
     else {
         diagnostics(5, "Resuming Source string");


### PR DESCRIPTION
The segfaults happen when `g_parser_depth` is -1, e.g. with `latex2rtf notexist` or `latex2rtf -d4 box`

Also finally resolve a compiler warning for a comparison between pointer and zero character constant.